### PR TITLE
Revert "Bump hexo-renderer-marked from 6.2.0 to 6.3.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "hexo-generator-index": "^3.0.0",
         "hexo-generator-tag": "^2.0.0",
         "hexo-renderer-ejs": "^2.0.0",
-        "hexo-renderer-marked": "^6.3.0",
+        "hexo-renderer-marked": "^6.0.0",
         "hexo-renderer-stylus": "^3.0.1",
         "hexo-server": "^3.0.0",
         "hexo-theme-landscape": "^1.0.0",
@@ -1188,9 +1188,9 @@
       }
     },
     "node_modules/hexo-renderer-marked": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/hexo-renderer-marked/-/hexo-renderer-marked-6.3.0.tgz",
-      "integrity": "sha512-V/ATcJ+tZHkTJSbScPzzHKmrwVMohU8i9MfuX9jp07Un/NpPtaTP821unP3JPu+O1nNLWMi+3xRbFRdm+8vajw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmmirror.com/hexo-renderer-marked/-/hexo-renderer-marked-6.2.0.tgz",
+      "integrity": "sha512-/TwgQCAmqYIyxONzrgqokw0n8rU6W/lCtgbjhWcMoZxhwTaQCYpzaO0+sdu+PKXf9BL4910pg+xAbeFaqqIIrA==",
       "dependencies": {
         "dompurify": "^3.0.3",
         "hexo-util": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hexo-generator-index": "^3.0.0",
     "hexo-generator-tag": "^2.0.0",
     "hexo-renderer-ejs": "^2.0.0",
-    "hexo-renderer-marked": "^6.3.0",
+    "hexo-renderer-marked": "^6.0.0",
     "hexo-renderer-stylus": "^3.0.1",
     "hexo-server": "^3.0.0",
     "hexo-theme-landscape": "^1.0.0",


### PR DESCRIPTION
Reverts Petalzu/petalzu.github.io#6